### PR TITLE
Fix client creation

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -144,7 +144,12 @@ export function args() {
 			argv.context = context;
 		})
 		.middleware(async (argv) => {
-			argv.distributor = await Distributor.create(argv.context as Context);
+			argv.getDistributor = async () => {
+				if (!argv.distributor) {
+					argv.distributor = await Distributor.create(argv.context as Context);
+				}
+				return argv.distributor;
+			};
 		})
 		.option('s', {
 			alias: 'seed',

--- a/src/args.ts
+++ b/src/args.ts
@@ -176,7 +176,7 @@ export function args() {
 			demandOption: true,
 			describe: 'log level',
 			choices: ['trace', 'debug', 'info', 'warn', 'error'],
-			default: 'info',
+			default: 'error',
 		})
 		.option('ttl', {
 			demandOption: true,

--- a/src/commands/addBlueprint.ts
+++ b/src/commands/addBlueprint.ts
@@ -21,7 +21,7 @@ export default {
 	},
 	handler: async (argv) => {
 		const context: Context = argv.context;
-		const distributor: Distributor = argv.distributor;
+		const distributor: Distributor = await argv.getDistributor();
 		let id = await distributor.uploadBlueprint(context.relay.peerId, {
 			name: argv.name,
 			dependencies: argv.deps,

--- a/src/commands/createService.ts
+++ b/src/commands/createService.ts
@@ -14,7 +14,7 @@ export default {
 	},
 	handler: async (argv) => {
 		const context: Context = argv.context;
-		const distributor: Distributor = argv.distributor;
+		const distributor: Distributor = await argv.getDistributor();
 		const serviceId = await distributor.createService(context.relay.peerId, argv.id);
 		console.log(`service id: ${serviceId}`);
 		console.log('service created successfully');

--- a/src/commands/deployApp.ts
+++ b/src/commands/deployApp.ts
@@ -218,7 +218,7 @@ export default {
 	handler: async (argv: any) => {
 		const input: string = argv.i;
 		const output: string = argv.o;
-		await deployApp(argv.distributor, argv.context, input, output);
+		await deployApp(await argv.getDistributor(), argv.context, input, output);
 		process.exit(0);
 	},
 };

--- a/src/commands/getInterface.ts
+++ b/src/commands/getInterface.ts
@@ -20,7 +20,7 @@ export default {
 	},
 	handler: async (argv) => {
 		const context: Context = argv.context;
-		const distributor: Distributor = argv.distributor;
+		const distributor: Distributor = await argv.getDistributor();
 
 		const interfaces = await distributor.getInterface(argv.id, context.relay.peerId);
 		if (Boolean(argv.expand)) {

--- a/src/commands/getInterfaces.ts
+++ b/src/commands/getInterfaces.ts
@@ -13,7 +13,7 @@ export default {
 	},
 	handler: async (argv) => {
 		const context: Context = argv.context;
-		const distributor: Distributor = argv.distributor;
+		const distributor: Distributor = await argv.getDistributor();
 
 		const interfaces = await distributor.getInterfaces(context.relay.peerId);
 		if (Boolean(argv.expand)) {

--- a/src/commands/getModules.ts
+++ b/src/commands/getModules.ts
@@ -13,7 +13,7 @@ export default {
 	},
 	handler: async (argv) => {
 		const context: Context = argv.context;
-		const distributor: Distributor = argv.distributor;
+		const distributor: Distributor = await argv.getDistributor();
 		let modules = await distributor.getModules(context.relay.peerId);
 
 		if (argv.pretty) {

--- a/src/commands/newService.ts
+++ b/src/commands/newService.ts
@@ -28,7 +28,7 @@ export default {
 	},
 	handler: async (argv) => {
 		const context: Context = argv.context;
-		const distributor: Distributor = argv.distributor;
+		const distributor: Distributor = await argv.getDistributor();
 
 		const node = context.relay;
 		const blueprintName = argv.name as string;

--- a/src/commands/runAir.ts
+++ b/src/commands/runAir.ts
@@ -29,7 +29,7 @@ export default {
 	},
 	handler: async (argv) => {
 		const context: Context = argv.context;
-		const distributor: Distributor = argv.distributor;
+		const distributor: Distributor = await argv.getDistributor();
 
 		const fileData = await fs.readFile(argv.path);
 		const air = fileData.toString('utf-8');

--- a/src/commands/runAir.ts
+++ b/src/commands/runAir.ts
@@ -42,7 +42,9 @@ export default {
 			return {};
 		};
 
-		const [particleId, _promise] = await distributor.runAir(air, callback, argv.data);
+		const [particleId, promise] = await distributor.runAir(air, callback, argv.data);
 		log.warn(`Particle id: ${particleId}. Waiting for results... Press Ctrl+C to stop the script.`);
+		await promise;
+		process.exit(0);
 	},
 };

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -35,7 +35,7 @@ type ConfigArgs = {
 	},
 	handler: async (argv) => {
 		const context: Context = argv.context;
-		const distributor: Distributor = argv.distributor;
+		const distributor: Distributor = await argv.getDistributor();
 
 		const module = await getModule(argv.path, argv.name, argv.configPath);
 		log.debug(`uploading module ${module.config.name} to node ${context.relay.peerId} with config:`);

--- a/src/distributor.ts
+++ b/src/distributor.ts
@@ -137,6 +137,14 @@ export class Distributor {
 		this.modules = [];
 	}
 
+	async closeClient(): Promise<void> {
+		if (!this.client) {
+			return;
+		}
+
+		await this.client.disconnect();
+	}
+
 	async load_modules() {
 		this.modules = [
 			{

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,22 @@
 #!/usr/bin/env node
 
+import { setLogLevel } from '@fluencelabs/fluence';
+import yargs from 'yargs';
 import { args } from './args';
+import { Distributor } from './distributor';
 
 export const DEFAULT_NODE_IDX = 3;
 
-if (typeof process === 'object') {
-	args();
-}
+const main = async () => {
+	if (typeof process !== 'object') {
+		return;
+	}
+
+	const res = await args();
+
+	// TODO:: it doesn't work. Need to find out why and remove all process.exit(0) calls
+	const d = res.distributor as Distributor;
+	await d?.closeClient();
+};
+
+main();


### PR DESCRIPTION
Lazily creating client, so it doesn't flood console when it's not needed.
Setting default error level to 'error' to hide stuff like "particle expired ...'